### PR TITLE
Update customize_airootfs.sh

### DIFF
--- a/archiso/airootfs/root/customize_airootfs.sh
+++ b/archiso/airootfs/root/customize_airootfs.sh
@@ -16,6 +16,7 @@ chown -R liveuser:users /home/liveuser
 #Fixes Permission issues with Claamares after install
 echo "%wheel ALL=(ALL) ALL" >> /etc/sudoers
 echo "liveuser ALL=(ALL) ALL" >> /etc/sudoers
+chown root:root /etc/sudoers /etc/sudoers.d -R
 
 sed -i 's/#\(PermitRootLogin \).\+/\1yes/' /etc/ssh/sshd_config
 sed -i "s/#Server/Server/g" /etc/pacman.d/mirrorlist

--- a/archiso/airootfs/root/customize_airootfs.sh
+++ b/archiso/airootfs/root/customize_airootfs.sh
@@ -13,7 +13,9 @@ cp -aT /etc/skel/ /root/
 useradd -m -p "" -g users -G "adm,audio,floppy,log,network,rfkill,scanner,storage,optical,power,wheel" -s /bin/zsh liveuser
 #chmod 700 /root
 chown -R liveuser:users /home/liveuser
-
+#Fixes Permission issues with Claamares after install
+echo "%wheel ALL=(ALL) ALL" >> /etc/sudoers
+echo "liveuser ALL=(ALL) ALL" >> /etc/sudoers
 
 sed -i 's/#\(PermitRootLogin \).\+/\1yes/' /etc/ssh/sshd_config
 sed -i "s/#Server/Server/g" /etc/pacman.d/mirrorlist

--- a/archiso/airootfs/root/customize_airootfs.sh
+++ b/archiso/airootfs/root/customize_airootfs.sh
@@ -13,7 +13,7 @@ cp -aT /etc/skel/ /root/
 useradd -m -p "" -g users -G "adm,audio,floppy,log,network,rfkill,scanner,storage,optical,power,wheel" -s /bin/zsh liveuser
 #chmod 700 /root
 chown -R liveuser:users /home/liveuser
-#Fixes Permission issues with Claamares after install
+#Fixes Permission issues with Calamares after install
 echo "%wheel ALL=(ALL) ALL" >> /etc/sudoers
 echo "liveuser ALL=(ALL) ALL" >> /etc/sudoers
 chown root:root /etc/sudoers /etc/sudoers.d -R


### PR DESCRIPTION
This was done because after the first build, The ISO would build fine however Calmares would complain about permissions and would crash. Adding these two lines fixed the permission issue. After next build everything worked fine as expected. Hence I updated this script for future reference.